### PR TITLE
[WIP] New Story: Display mythology names instead of ids

### DIFF
--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -10,9 +10,11 @@
       </ul>
     </div>
   <% end %>
+
+  <%# To Do: consider switching to simple form %>
   <div>
     <%= form.label :mythology_id %>
-    <%= form.select :mythology_id, [1, 2, 3, 4] %>
+    <%= form.select :mythology_id, @mythologies.map { |mythology| [mythology.name, mythology.id] } %>
     <%= form.label :title %>
     <%= form.text_field :title %>
     <%= form.text_area :body, placeholder: 'AI will generate this', style: 'display:none' %>


### PR DESCRIPTION
## Problem

On the 'New Story' page there is a dropdown menu representing the available mythologies: currently, the options to choose from are the numbers from 1 to 4, representing the mythologies IDs. The updated code shall display the mythology names (including 'Unspecified') in the dropdown instead of the ID numbers.

See #8

## Solution

Replacing the hard-coded integers representing both the value and display text for each option with dyamically-generated options where each option consists of an array of two elements: [mythology.name, mythology.id]. The first element of this inner array is used as the display text, and the second element is used as the value associated with that option.

## Details

i referred to the ruby docs for how to use the select helper.
Next: will try and replace the form with a simple form (after installing the required gem) to improve code clarity.
