### PR TITLE
fix: remove <abbr> element from form labels

### DIFF
--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -15,10 +15,10 @@
     default: @mythologies.first,
     input_html: { class: 'rounded', style: 'margin-left: 15px;' } %>
     <%= f.input :title,
-    input_html: { class: 'rounded mt-5', style: 'margin-left: 49px;' } %>
+    input_html: { class: 'rounded mt-5', style: 'margin-left: 62px;' } %>
     <%= f.input :creativity, collection: %w[Conservative Balanced Inventive],
     default: 'Conservative',
-    input_html: { class: 'rounded mt-5', style: 'margin-left: 10px;' } %>
+    input_html: { class: 'rounded mt-5', style: 'margin-left: 22px;' } %>
     <%= f.hidden_field :body, input_placeholder: 'AI will generate this' %>
     <%= f.submit class: 'border font-bold py-2 px-4 rounded block mt-5' %>
   </div>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -7,7 +7,7 @@ en:
       mark: '*'
       # You can uncomment the line below if you need to overwrite the whole required html.
       # When using html, text and mark won't be used.
-      # html: '<abbr title="required">*</abbr>'
+      html: ''
     error_notification:
       default_message: "Please review the problems below:"
     # Examples


### PR DESCRIPTION
## Problem

Unwanted <abbr> in form labels
See #23 and #22

## Solution

Updated config/locales/simple_form.en.yml to overwrite the required html and remove the <abbr> element altogether.

## Details

This overrides the simple_form gem default behavior on how to indicate mandatory fields in forms.
